### PR TITLE
Now possible to configure base url

### DIFF
--- a/frontend/src/main/resources/static/assets/js/ml5/utils.js
+++ b/frontend/src/main/resources/static/assets/js/ml5/utils.js
@@ -218,7 +218,7 @@
 
     function defaultSystemConfig(){
         console.log("default system config");
-        apiBaseUrlField.value = apiBaseUrl;
+        apiBaseUrlField.value = window.location.origin;
         return false;//do not follow href
         }
 

--- a/frontend/src/main/resources/static/templates/index.ftlh
+++ b/frontend/src/main/resources/static/templates/index.ftlh
@@ -38,7 +38,7 @@
 
 <script>
 
-    const DEFAULT_API_BASE_URL = "http://localhost";
+    const DEFAULT_API_BASE_URL = window.location.origin;
 
     let apiBaseUrl;
 

--- a/frontend/src/main/resources/static/templates/settings.ftlh
+++ b/frontend/src/main/resources/static/templates/settings.ftlh
@@ -20,7 +20,7 @@
 
     <script>
 
-      const DEFAULT_API_BASE_URL = "http://localhost";
+      const DEFAULT_API_BASE_URL = window.location.origin;
   
       let apiBaseUrl;
   

--- a/frontend/src/main/resources/static/templates/webcam.ftlh
+++ b/frontend/src/main/resources/static/templates/webcam.ftlh
@@ -25,7 +25,7 @@
 
     <script>
 
-        const DEFAULT_API_BASE_URL = "http://localhost";
+        const DEFAULT_API_BASE_URL = window.location.origin;
     
         let apiBaseUrl;
     


### PR DESCRIPTION
We good, offline and all.
We default the BASE URL as window.location.origin

To access a working backend (for demo etc) we go to Settings and set the new base url eg ngrok 